### PR TITLE
Add transformers 5.x and RTX 5090 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,2 @@
+[submodule "fast-hadamard-transform"]
+	url = https://github.com/nevertmr/fast-hadamard-transform.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 # ResQ: Mixed-Precision Quantization of Large Language Models with Low-Rank Residuals
 This repository contains the code for the submitted paper ResQ
 
+> **Note (fork):** 이 포크는 transformers 5.x 및 RTX 5090 (Blackwell, sm_120) 환경 호환성 패치를 포함합니다.
+> 원본 레포는 Python 3.9 / PyTorch 2.3.0 / transformers 4.48.1 / CUDA 11.8 / A100 기준입니다.
+>
+> **테스트 환경:** Python 3.12 / PyTorch 2.12.0.dev (cu128) / transformers 5.2.0 / CUDA 12.8 / RTX 5090
+>
+> 주요 변경사항:
+> - `modeling_llama_2.py`: rope_theta 호환, column_order 조건부 전달, RotaryEmbedding inv_freq 재초기화
+> - `get_basis.py`, `eval_utils.py`: LlamaDecoderLayer 반환값 tuple/tensor 호환 처리
+> - `ptq.py`, `get_basis.py`: Qwen2-VL import 에러 방어
+> - `fsdp_trainer.py`: is_torch_compile_available 제거 대응
+> - `fast-hadamard-transform`: compute_120 (sm_120) 아키텍처 추가
 
 
 ## Abstract

--- a/fake_quant/ptq.py
+++ b/fake_quant/ptq.py
@@ -15,7 +15,10 @@ from transformers import AutoConfig, AutoTokenizer, AutoProcessor
 from eval_utils.main import ptq_model
 from eval_utils.modeling_llama_2 import LlamaForCausalLM
 from eval_utils.modeling_qwen2 import Qwen2ForCausalLM
-from eval_utils.modeling_qwen2_vl import Qwen2VLForConditionalGeneration
+try:
+    from eval_utils.modeling_qwen2_vl import Qwen2VLForConditionalGeneration
+except ImportError:
+    Qwen2VLForConditionalGeneration = None
 from utils import data_utils, eval_utils, utils
 from utils.process_args import process_args_ptq
 from lm_eval import evaluator

--- a/fake_quant/train_utils/fsdp_trainer.py
+++ b/fake_quant/train_utils/fsdp_trainer.py
@@ -59,7 +59,7 @@ from transformers.utils import (
     is_in_notebook,
     is_peft_available,
     is_sagemaker_mp_enabled,
-    is_torch_compile_available,
+    # is_torch_compile_available,  # removed in transformers >= 5.x
     is_torch_xla_available,
     logging,
     XLA_FSDPV2_MIN_VERSION,
@@ -543,7 +543,7 @@ class FSDPTrainer(Trainer):
         self._memory_tracker.stop_and_update_metrics()
 
         # torch.compile
-        if args.torch_compile and not is_torch_compile_available():
+        if args.torch_compile and not hasattr(torch, 'compile'):
             raise RuntimeError("Using torch.compile requires PyTorch 2.0 or higher.")
 
         self.is_fsdp_xla_v2_enabled = args.fsdp_config.get("xla_fsdp_v2", False)

--- a/fake_quant/utils/eval_utils.py
+++ b/fake_quant/utils/eval_utils.py
@@ -110,7 +110,7 @@ def evaluator(model, testenc, dev, args):
                 position_ids=position_ids,
                 position_embeddings=position_embeddings,
             )
-            outs[j] = outputs[0]
+            outs[j] = outputs[0] if isinstance(outputs, tuple) else outputs
         layers[i] = layer.cpu()
         del layer
         torch.cuda.empty_cache()


### PR DESCRIPTION
## Summary
transformers 5.x 및 RTX 5090 (Blackwell, sm_120) 환경에서 ResQ가 정상 동작하도록 호환성 패치 적용.

## 변경사항

### Critical
- **`_init_weights` RotaryEmbedding 재초기화**: `from_pretrained` 시 `inv_freq` non-persistent buffer가 손상되는 문제 해결 (PPL 1402 -> 9.76)
- **Layer output tuple/tensor 호환**: `LlamaDecoderLayer.forward()`가 tensor를 반환하도록 변경된 API 대응

### High
- **`rope_theta` 위치 변경 대응**: `config.rope_scaling` dict에서 추출
- **`column_order` 조건부 전달**: `None`일 때 `nn.Linear`에 전달하지 않도록 수정

### Medium
- **fast-hadamard-transform sm_120 추가**: 서브모듈을 포크로 변경, compute_120 gencode 추가

### Low
- **Qwen2-VL import 방어**: try/except 처리
- **`is_torch_compile_available` 제거 대응**: `hasattr(torch, 'compile')`로 대체

## 변경 파일
- `fake_quant/eval_utils/modeling_llama_2.py`
- `fake_quant/get_basis.py`
- `fake_quant/ptq.py`
- `fake_quant/train_utils/fsdp_trainer.py`
- `fake_quant/utils/eval_utils.py`
- `.gitmodules` (서브모듈 URL 변경)
- `README.md`

## Test
Llama-3.2-1B / Wikitext-2 / RTX 5090 + CUDA 12.8 + transformers 5.2.0

| Configuration | PPL | Paper |
|---|---|---|
| FP16 Baseline | 9.76 | ~9.8 |
| W4A4KV4 ResQ | 12.02 | ~12.4 |

Closes #1